### PR TITLE
[UPDATE] -Initializes 'assignValues' method in the '__toString' method to fix problem with use of deserialization

### DIFF
--- a/src/EnumTrait.php
+++ b/src/EnumTrait.php
@@ -99,7 +99,7 @@ trait EnumTrait
      */
     public function __toString(): string
     {
-        $values ?? static::assignValues();
+        static::assignValues();
         $description = static::$descriptions[array_search($this->value, static::$values)] ?? $this->value;
 
         return (string) $description;

--- a/src/EnumTrait.php
+++ b/src/EnumTrait.php
@@ -97,8 +97,9 @@ trait EnumTrait
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
+        $values ?? static::assignValues();
         $description = static::$descriptions[array_search($this->value, static::$values)] ?? $this->value;
 
         return (string) $description;


### PR DESCRIPTION
Initializes 'assignValues' method in the '__toString' method to fix problem with use of deserialization.